### PR TITLE
Feature/add redis namespace support

### DIFF
--- a/.env
+++ b/.env
@@ -4,6 +4,7 @@ APP_HOST=http://devkit-lti1p3.localhost
 APP_SECRET=3f33e29c19d9d24f0dccb90a3f84db04
 APP_API_KEY=dcf8cb90ac4db043f33e29d2419d93f0
 REDIS_CACHE_DSN=redis://devkit_lti1p3_redis:6379
+REDIS_CACHE_NAMESPACE=devkit
 REDIS_COMMANDER_URL=http://localhost:8081/
 #TRUSTED_PROXIES=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
 #TRUSTED_HOSTS='^(localhost|example\.com)$'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 CHANGELOG
 =========
 
-Unreleased
+2.4.5
 -----
 * Added `lineitem` to AGS claim
 * Added Redis namespace support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 Unreleased
 -----
 * Added `lineitem` to AGS claim
+* Added Redis namespace support
 
 2.4.4
 -----

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -10,6 +10,8 @@ parameters:
     application_vendors: '%kernel.project_dir%/vendor/composer/installed.php'
     application_version: '2.4.2'
     container.dumper.inline_factories: true
+    cache.redis.namespace: '%env(default:cache.redis.namespace.default:REDIS_CACHE_NAMESPACE)%'
+    cache.redis.namespace.default: 'devkit'
 
 services:
     _defaults:

--- a/src/DependencyInjection/Compiler/RedisPass.php
+++ b/src/DependencyInjection/Compiler/RedisPass.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace App\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class RedisPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $redisCacheNamespace = $container->getParameter('cache.redis.namespace');
+        $container
+            ->getDefinition('cache.adapter.redis')
+            ->setArgument('$namespace', $redisCacheNamespace);
+    }
+}

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -21,6 +21,7 @@
 namespace App;
 
 use App\DependencyInjection\Compiler\ConfigurationPass;
+use App\DependencyInjection\Compiler\RedisPass;
 use App\DependencyInjection\Security\Factory\ApiKeyFactory;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
@@ -64,6 +65,7 @@ class Kernel extends BaseKernel
         $confDir = $this->getProjectDir().'/config';
 
         $container->addCompilerPass(new ConfigurationPass());
+        $container->addCompilerPass(new RedisPass());
 
         $loader->load($confDir.'/{packages}/*'.self::CONFIG_EXTS, 'glob');
         $loader->load($confDir.'/{packages}/'.$this->environment.'/*'.self::CONFIG_EXTS, 'glob');


### PR DESCRIPTION
Changes:
- Added redis namespace support (`REDIS_CACHE_NAMESPACE` environment variable)
- if the given environment variable is not defined, it falls back to `devkit` namespace