### PR TITLE
service call exception handeling

### DIFF
--- a/src/Action/Tool/Service/LtiServiceClientAction.php
+++ b/src/Action/Tool/Service/LtiServiceClientAction.php
@@ -113,8 +113,9 @@ class LtiServiceClientAction
             try {
                 $response = $this->client->request($registration, $method, $serviceUrl, $options, $scopes);
             } catch (LtiExceptionInterface $exception) {
-                if ($exception->getPrevious() instanceof RequestException){
-                    $response = $exception->getPrevious()->getResponse();
+                $previous = $exception->getPrevious();
+                if ($previous instanceof RequestException && $previous->getResponse() !== null) {
+                    $response = $previous->getResponse();
                 } else {
                     throw $exception;
                 }


### PR DESCRIPTION
prevent response null pointer in case when RequestException doesn't contains response

example 
curl inside docker the container can't reach host on host machine