### PR TITLE
Feature TR-4685 NRPS membership difference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+2.5.0
+-----
+
+* Added rel="differences" link to the NRPS membership service
+* Added time-based membership differences exposure to the NRPS membership service
+* Added members' soft delete
+
 2.4.7
 -----
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -8,7 +8,7 @@ parameters:
     application_env: '%env(resolve:APP_ENV)%'
     application_api_key: '%env(resolve:APP_API_KEY)%'
     application_vendors: '%kernel.project_dir%/vendor/composer/installed.php'
-    application_version: '2.4.7'
+    application_version: '2.5.0'
     container.dumper.inline_factories: true
     cache.redis.namespace: '%env(default:cache.redis.namespace.default:REDIS_CACHE_NAMESPACE)%'
     cache.redis.namespace.default: 'devkit'

--- a/src/Nrps/MembershipService.php
+++ b/src/Nrps/MembershipService.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ *
+ * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
+ */
+
+declare(strict_types=1);
+
+namespace App\Nrps;
+
+use OAT\Library\Lti1p3Nrps\Factory\Member\MemberFactoryInterface;
+use OAT\Library\Lti1p3Nrps\Model\Member\MemberCollection;
+use OAT\Library\Lti1p3Nrps\Model\Member\MemberInterface;
+use OAT\Library\Lti1p3Nrps\Model\Membership\MembershipInterface;
+
+class MembershipService
+{
+    public const UPDATED_AT_FIELD = 'updated_at';
+
+    /** @var MembershipRepository */
+    private $repository;
+
+    /** @var MemberFactoryInterface */
+    private $memberFactory;
+
+    public function __construct(MembershipRepository $repository, MemberFactoryInterface $memberFactory)
+    {
+        $this->repository = $repository;
+        $this->memberFactory = $memberFactory;
+    }
+
+    public function findMembership(string $identifier, array $statuses = null): ?MembershipInterface
+    {
+        return $this->repository->find($identifier, $statuses);
+    }
+
+    public function updateMembership(MembershipInterface $membership, array $rawMembers): void
+    {
+        $memberCollection = new MemberCollection();
+        $now = time();
+
+        foreach ($rawMembers as $member) {
+            unset($member[static::UPDATED_AT_FIELD]);
+            $newMember = $this->memberFactory->create($member);
+
+            if (!$membership->getMembers()->has($newMember->getUserIdentity()->getIdentifier())) {
+                $this->setUpdatedAtToMember($newMember, $now);
+            }
+
+            $memberCollection->add($newMember);
+        }
+
+        /** @var MemberInterface $existingMember */
+        foreach ($membership->getMembers() as $existingMember) {
+            $existingMemberUpdatedAt = $existingMember->getProperties()->get(static::UPDATED_AT_FIELD);
+            $existingMember->getProperties()->remove(static::UPDATED_AT_FIELD);
+            $memberId = $existingMember->getUserIdentity()->getIdentifier();
+
+            if (!$memberCollection->has($memberId)) {
+                $this->setUpdatedAtToMember($existingMember, $now);
+                $existingMember->setStatus(MemberInterface::STATUS_DELETED);
+
+                $memberCollection->add($existingMember);
+            } else {
+                $member = $memberCollection->get($memberId);
+                $this->setUpdatedAtToMember(
+                    $member,
+                    $existingMemberUpdatedAt && $member == $existingMember
+                        ? $existingMemberUpdatedAt
+                        : $now
+                );
+            }
+        }
+
+        $membership->setMembers($memberCollection);
+
+        $this->repository->save($membership);
+    }
+
+    private function setUpdatedAtToMember(MemberInterface $member, int $now): void
+    {
+        $member->getProperties()->add([static::UPDATED_AT_FIELD => $now]);
+    }
+}

--- a/src/Nrps/MembershipService.php
+++ b/src/Nrps/MembershipService.php
@@ -74,7 +74,8 @@ class MembershipService
 
             if (!$memberCollection->has($memberId)) {
                 $this->setUpdatedAtToMember($existingMember, $now);
-                $existingMember->setStatus(MemberInterface::STATUS_DELETED);
+                $existingMember->setStatus(MemberInterface::STATUS_DELETED)
+                    ->getProperties()->add(['status' => MemberInterface::STATUS_DELETED]);
 
                 $memberCollection->add($existingMember);
             } else {

--- a/src/Nrps/MembershipServiceServerBuilder.php
+++ b/src/Nrps/MembershipServiceServerBuilder.php
@@ -27,7 +27,6 @@ use OAT\Library\Lti1p3Nrps\Model\Member\MemberCollection;
 use OAT\Library\Lti1p3Nrps\Model\Member\MemberInterface;
 use OAT\Library\Lti1p3Nrps\Model\Membership\MembershipInterface;
 use OAT\Library\Lti1p3Nrps\Service\Server\Builder\MembershipServiceServerBuilderInterface;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -99,9 +98,11 @@ class MembershipServiceServerBuilder implements MembershipServiceServerBuilderIn
         $filteredMembers = array_filter(
             $membership->getMembers()->all(),
             static function (MemberInterface $member) use ($role, $since) {
-                return $member->getStatus() !== MemberInterface::STATUS_DELETED
-                       && ($role === null || in_array($role, $member->getRoles(), true))
-                       && ($since === null || $member->getProperties()->get('updated_at', 0) > $since);
+                return ($role === null || in_array($role, $member->getRoles(), true))
+                       && (
+                           $since === null
+                           || $member->getProperties()->get(MembershipService::UPDATED_AT_FIELD, 0) > $since
+                       );
             }
         );
 

--- a/src/Nrps/MembershipServiceServerBuilder.php
+++ b/src/Nrps/MembershipServiceServerBuilder.php
@@ -35,19 +35,19 @@ class MembershipServiceServerBuilder implements MembershipServiceServerBuilderIn
     /** @var RequestStack */
     private $requestStack;
 
-    /** @var MembershipRepository */
-    private $repository;
+    /** @var MembershipService */
+    private $service;
 
     /** @var DefaultMembershipFactory */
     private $factory;
 
     public function __construct(
         RequestStack $requestStack,
-        MembershipRepository $repository,
+        MembershipService $service,
         DefaultMembershipFactory $factory
     ) {
         $this->requestStack = $requestStack;
-        $this->repository = $repository;
+        $this->service = $service;
         $this->factory = $factory;
     }
 
@@ -86,7 +86,7 @@ class MembershipServiceServerBuilder implements MembershipServiceServerBuilderIn
         if ($membershipIdentifier === 'default') {
             $membership = $this->factory->create();
         } else {
-            $membership = $this->repository->find($membershipIdentifier);
+            $membership = $this->service->findMembership($membershipIdentifier);
         }
 
         if (null === $membership || $membership->getContext()->getIdentifier() !== $contextIdentifier) {
@@ -102,7 +102,8 @@ class MembershipServiceServerBuilder implements MembershipServiceServerBuilderIn
                        && (
                            $since === null
                            || $member->getProperties()->get(MembershipService::UPDATED_AT_FIELD, 0) > $since
-                       );
+                       )
+                       && ($since !== null || $member->getStatus() !== MemberInterface::STATUS_DELETED);
             }
         );
 


### PR DESCRIPTION
# [TR-4685](https://oat-sa.atlassian.net/browse/TR-4685)

https://user-images.githubusercontent.com/2943256/203092331-3c24acf6-2f5e-4fce-825c-426226b86360.mov

## How to test

1. Create a custom NRPS membership
2. Call the platform's NRPS membership endpoint
3. Verify the Link header has the `rel="difference"` value
4. Call that link, make sure it returns an empty membership set
5. Update the original membership
6. Call the link again
7. Make sure the differences are displayed

This PR aims to bring [Membership Differences](https://www.imsglobal.org/spec/lti-nrps/v2p0#membership-differences) to the NRPS implementation in DevKit.

This feature is required to re-submit for the LTI Advantage Platform certification.

The validation with the IMS' test tool [went well](https://oat-sa.atlassian.net/wiki/spaces/NEX/pages/1899266885/1EdTech+former+IMS+certification+procedure+LTI+1.3+platform#Submitting-the-results), will merge once the final confirmation from IMS has been received.
