### PR TITLE
fix: apply latest `lib-lti1p3-proctoring` with extra-time fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "oat-sa/lib-lti1p3-basic-outcome": "^4.1",
         "oat-sa/lib-lti1p3-deep-linking": "^4.0",
         "oat-sa/lib-lti1p3-nrps": "^7.0",
-        "oat-sa/lib-lti1p3-proctoring": "^0.4.0",
+        "oat-sa/lib-lti1p3-proctoring": "^0.5.0",
         "oat-sa/lib-lti1p3-submission-review": "^0.1.0",
         "ramsey/uuid": "^3.9 || ^4",
         "sensio/framework-extra-bundle": "^6.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d0b51816bde6048003d8b2dcec14b83a",
+    "content-hash": "8e27f30286f54253b26bfd374d0a79f8",
     "packages": [
         {
             "name": "brick/math",
@@ -1552,16 +1552,16 @@
         },
         {
             "name": "oat-sa/lib-lti1p3-proctoring",
-            "version": "0.4.0",
+            "version": "0.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/lib-lti1p3-proctoring.git",
-                "reference": "7b09e4793fe4c176e64d2f8dcf29f172908e195b"
+                "reference": "792a0e4619702b344ef5a0ce6c26fe4f47d9f06f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/lib-lti1p3-proctoring/zipball/7b09e4793fe4c176e64d2f8dcf29f172908e195b",
-                "reference": "7b09e4793fe4c176e64d2f8dcf29f172908e195b",
+                "url": "https://api.github.com/repos/oat-sa/lib-lti1p3-proctoring/zipball/792a0e4619702b344ef5a0ce6c26fe4f47d9f06f",
+                "reference": "792a0e4619702b344ef5a0ce6c26fe4f47d9f06f",
                 "shasum": ""
             },
             "require": {
@@ -1589,9 +1589,9 @@
             "description": "OAT LTI 1.3 Proctoring Library",
             "support": {
                 "issues": "https://github.com/oat-sa/lib-lti1p3-proctoring/issues",
-                "source": "https://github.com/oat-sa/lib-lti1p3-proctoring/tree/0.4.0"
+                "source": "https://github.com/oat-sa/lib-lti1p3-proctoring/tree/0.5.0"
             },
-            "time": "2021-09-27T13:11:47+00:00"
+            "time": "2023-01-24T17:22:06+00:00"
         },
         {
             "name": "oat-sa/lib-lti1p3-submission-review",


### PR DESCRIPTION
This PR aim to bring fix for update acs by 0 extra time in devkit proctoring functionality