### PR TITLE
fix: fixed deep linking icon url validation

### DIFF
--- a/templates/launch/blocks/deepLinkingItem.html.twig
+++ b/templates/launch/blocks/deepLinkingItem.html.twig
@@ -22,7 +22,7 @@
                                     {% endif %}
                                     <dt>Description</dt>
                                     <dd>{{ resource.text }}</dd>
-                                    {% if resource.icon is defined %}
+                                    {% if resource.icon is defined and resource.icon.url is defined %}
                                         <dt>Icon</dt>
                                         <dd><img height="20px" width="20px" src="{{ resource.icon.url }}"/></dd>
                                     {% endif %}


### PR DESCRIPTION
Fixed the validation of the icon url after returning from a deep linking launch.