### PR TITLE
Feature/additive custom claims UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ CHANGELOG
 
 * Made claim selection non-destructive
 
+2.10.3
+------
+
+Fixed handling of concurrent AGS requests
+
 2.10.2
 ------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.11.0
+------
+
+* Made claim selection non-destructive
+
 2.10.2
 ------
 

--- a/config/devkit/claims.yaml
+++ b/config/devkit/claims.yaml
@@ -81,6 +81,7 @@ parameters:
                 deliverySettings.review.showScore: 'true'
                 deliverySettings.review.showQuestion: 'false'
                 deliverySettings.review.showUnShuffled: 'true'
+                deliverySettings.review.allInOne: 'false'
         Custom – Proctored:
             name: !php/const \OAT\Library\Lti1p3Core\Message\Payload\LtiMessagePayloadInterface::CLAIM_LTI_CUSTOM
             value:
@@ -92,3 +93,7 @@ parameters:
                 deliverySettings.plugins.add: 'taoQtiNuiTest/runner/plugins/panel/a11y/plugin'
                 deliverySettings.plugins.remove: 'taoQtiNuiTest/runner/plugins/tools/highlighter/plugin,taoQtiNuiTest/runner/plugins/tools/scratchpad/plugin'
                 deliverySettings.plugins: '{"readAloud": {"readAloudOption": "always-enabled"}, "a11yMenuPanel": {"openOnStart": true, "contrastTheme": {"enabled": true, "themes": ["default", "whiteOnBlue", "yellowOnBlack", "blueOnYellow", "greyOnGreen"]}, "groups": ["group-contrast", "group-pointer", "group-text", "group-zoom"]}}'
+        Custom – Item Runner:
+            name: !php/const \OAT\Library\Lti1p3Core\Message\Payload\LtiMessagePayloadInterface::CLAIM_LTI_CUSTOM
+            value:
+                deliverySettings.itemRunnerConfigElements: '{"ExtendedTextInteraction": {"spellCheckConfig": {"enabled": true, "providerId": "wproofreader", "providerConfig": {"lang": "nb_NO"}}}}'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -8,7 +8,7 @@ parameters:
     application_env: '%env(resolve:APP_ENV)%'
     application_api_key: '%env(resolve:APP_API_KEY)%'
     application_vendors: '%kernel.project_dir%/vendor/composer/installed.php'
-    application_version: '2.10.3'
+    application_version: '2.11.0'
     container.dumper.inline_factories: true
     cache.redis.namespace: '%env(default:cache.redis.namespace.default:REDIS_CACHE_NAMESPACE)%'
     cache.redis.namespace.default: 'devkit'

--- a/templates/platform/message/ltiResourceLinkLaunch.html.twig
+++ b/templates/platform/message/ltiResourceLinkLaunch.html.twig
@@ -225,7 +225,10 @@
         $(".editorClaim").click(function(event){
             try {
                 var claims = JSON.parse($("#lti_resource_link_launch_claims").val() || "{}");
-                claims[$(this).data('name')] = $(this).data('value');
+                claims[$(this).data('name')] = {
+                    ...$(this).data('value'),
+                    ...claims[$(this).data('name')]
+                };
                 $("#lti_resource_link_launch_claims").val(JSON.stringify(claims, undefined, 4));
                 $("#lti_resource_link_launch_claims").removeClass('is-invalid');
                 $("#lti_resource_link_launch_claims").addClass('is-valid');


### PR DESCRIPTION
This PR allows you to add preset claims (particularly custom claims) to the LtiResourceLink claims, without replacing what you already had there.

Test it by playing with the "Custom - Plugins", "Custom - Review", "Custom - Item Runner" claim preset buttons.

I also introduced some useful claims for TAO Advance features.

https://github.com/user-attachments/assets/adfa2a62-abdb-44e4-a814-832663c49daa



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new "Custom – Item Runner" claim with spell check enabled for Norwegian.
- **Bug Fixes**
  - Improved handling of concurrent AGS requests.
- **Enhancements**
  - Claim selection is now non-destructive, merging new data with existing claim values.
  - Updated the "Custom – Review" claim to adjust review settings.
- **Documentation**
  - Updated the changelog with entries for versions 2.11.0 and 2.10.3.
- **Chores**
  - Updated application version to 2.11.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->