### PR TITLE
Fix/additive custom claims arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.11.1
+------
+
+* Fixed claim selection for simple arrays
+
 2.11.0
 ------
 
@@ -118,7 +123,7 @@ Fixed handling of concurrent AGS requests
 -----
 
 * Updated LTI 1.3 bundle and libraries dependencies
-* Updated Symfony packages to version 5.3.x  
+* Updated Symfony packages to version 5.3.x
 * Updated devkit registration to be the default one
 
 2.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ CHANGELOG
 
 * Made claim selection non-destructive
 
+2.10.3
+------
+
+Fixed handling of concurrent AGS requests
+
 2.10.2
 ------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.11.0
+------
+
+* Made claim selection non-destructive
+
 2.10.2
 ------
 

--- a/config/devkit/claims.yaml
+++ b/config/devkit/claims.yaml
@@ -81,6 +81,7 @@ parameters:
                 deliverySettings.review.showScore: 'true'
                 deliverySettings.review.showQuestion: 'false'
                 deliverySettings.review.showUnShuffled: 'true'
+                deliverySettings.review.allInOne: 'false'
         Custom – Proctored:
             name: !php/const \OAT\Library\Lti1p3Core\Message\Payload\LtiMessagePayloadInterface::CLAIM_LTI_CUSTOM
             value:
@@ -92,3 +93,7 @@ parameters:
                 deliverySettings.plugins.add: 'taoQtiNuiTest/runner/plugins/panel/a11y/plugin'
                 deliverySettings.plugins.remove: 'taoQtiNuiTest/runner/plugins/tools/highlighter/plugin,taoQtiNuiTest/runner/plugins/tools/scratchpad/plugin'
                 deliverySettings.plugins: '{"readAloud": {"readAloudOption": "always-enabled"}, "a11yMenuPanel": {"openOnStart": true, "contrastTheme": {"enabled": true, "themes": ["default", "whiteOnBlue", "yellowOnBlack", "blueOnYellow", "greyOnGreen"]}, "groups": ["group-contrast", "group-pointer", "group-text", "group-zoom"]}}'
+        Custom – Item Runner:
+            name: !php/const \OAT\Library\Lti1p3Core\Message\Payload\LtiMessagePayloadInterface::CLAIM_LTI_CUSTOM
+            value:
+                deliverySettings.itemRunnerConfigElements: '{"ExtendedTextInteraction": {"spellCheckConfig": {"enabled": true, "providerId": "wproofreader", "providerConfig": {"lang": "nb_NO"}}}}'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -8,7 +8,7 @@ parameters:
     application_env: '%env(resolve:APP_ENV)%'
     application_api_key: '%env(resolve:APP_API_KEY)%'
     application_vendors: '%kernel.project_dir%/vendor/composer/installed.php'
-    application_version: '2.10.3'
+    application_version: '2.11.0'
     container.dumper.inline_factories: true
     cache.redis.namespace: '%env(default:cache.redis.namespace.default:REDIS_CACHE_NAMESPACE)%'
     cache.redis.namespace.default: 'devkit'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -8,7 +8,7 @@ parameters:
     application_env: '%env(resolve:APP_ENV)%'
     application_api_key: '%env(resolve:APP_API_KEY)%'
     application_vendors: '%kernel.project_dir%/vendor/composer/installed.php'
-    application_version: '2.11.0'
+    application_version: '2.11.1'
     container.dumper.inline_factories: true
     cache.redis.namespace: '%env(default:cache.redis.namespace.default:REDIS_CACHE_NAMESPACE)%'
     cache.redis.namespace.default: 'devkit'

--- a/templates/platform/message/ltiResourceLinkLaunch.html.twig
+++ b/templates/platform/message/ltiResourceLinkLaunch.html.twig
@@ -225,10 +225,17 @@
         $(".editorClaim").click(function(event){
             try {
                 var claims = JSON.parse($("#lti_resource_link_launch_claims").val() || "{}");
-                claims[$(this).data('name')] = {
-                    ...$(this).data('value'),
-                    ...claims[$(this).data('name')]
-                };
+                var name = $(this).data('name');
+                var value = $(this).data('value');
+
+                if (typeof value === 'object' && !Array.isArray(value)) {
+                    claims[name] = {
+                        ...value,
+                        ...claims[name]
+                    };
+                } else {
+                    claims[name] = value;
+                }
                 $("#lti_resource_link_launch_claims").val(JSON.stringify(claims, undefined, 4));
                 $("#lti_resource_link_launch_claims").removeClass('is-invalid');
                 $("#lti_resource_link_launch_claims").addClass('is-valid');

--- a/templates/platform/message/ltiResourceLinkLaunch.html.twig
+++ b/templates/platform/message/ltiResourceLinkLaunch.html.twig
@@ -225,7 +225,10 @@
         $(".editorClaim").click(function(event){
             try {
                 var claims = JSON.parse($("#lti_resource_link_launch_claims").val() || "{}");
-                claims[$(this).data('name')] = $(this).data('value');
+                claims[$(this).data('name')] = {
+                    ...$(this).data('value'),
+                    ...claims[$(this).data('name')]
+                };
                 $("#lti_resource_link_launch_claims").val(JSON.stringify(claims, undefined, 4));
                 $("#lti_resource_link_launch_claims").removeClass('is-invalid');
                 $("#lti_resource_link_launch_claims").addClass('is-valid');


### PR DESCRIPTION
Follow-up to https://github.com/oat-sa/devkit-lti1p3/pull/169.

After the previous change, a bug was found: selecting the "Roles" preset claim would insert:

`{"https://purl.imsglobal.org/spec/lti/claim/roles": {"0": "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner" }}`

instead of:

`{"https://purl.imsglobal.org/spec/lti/claim/roles": ["http://purl.imsglobal.org/vocab/lis/v2/membership#Learner"]}`

So now, we will handle Arrays and Objects differently.