### PR TITLE
fix: apply production-ready PHP configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 CHANGELOG
 =========
 
+2.11.4
+------
+
+* Apply production-ready PHP configuration
+
 2.11.3
 ------
 
 * Upgrade LTI 1.3 core library to fix compatibility issues
 * Upgraded PHP-FPM to version **8.4** in Docker image
-
 
 2.11.2
 ------

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -8,7 +8,7 @@ parameters:
     application_env: '%env(resolve:APP_ENV)%'
     application_api_key: '%env(resolve:APP_API_KEY)%'
     application_vendors: '%kernel.project_dir%/vendor/composer/installed.php'
-    application_version: '2.11.3'
+    application_version: '2.11.4'
     container.dumper.inline_factories: true
     cache.redis.namespace: '%env(default:cache.redis.namespace.default:REDIS_CACHE_NAMESPACE)%'
     cache.redis.namespace.default: 'devkit'

--- a/docker/kube/Dockerfile
+++ b/docker/kube/Dockerfile
@@ -11,7 +11,8 @@ RUN set -eux; \
             echo 'realpath_cache_size=4096K'; \
             echo 'realpath_cache_ttl=600'; \
         } >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini \
-        ;
+        ; \
+        mv /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini;
 #}}} fpm
 
 #{{{ composer


### PR DESCRIPTION
This is a follow up to #173 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 2.11.4.
  * Added a changelog entry for version 2.11.4.
  * Updated the PHP container to use the production PHP configuration by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->