### PR TITLE
fix: avoid forcing msgpack support in dev phpfpm pecl install

### DIFF
--- a/docker/phpfpm/Dockerfile
+++ b/docker/phpfpm/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
 
 RUN yes | pecl update-channels
 
-RUN yes | pecl install igbinary redis
+RUN printf "\n" | pecl install igbinary redis
 
 RUN docker-php-ext-install intl && \
     docker-php-ext-install gd && \


### PR DESCRIPTION
## Summary

- Replace `yes | pecl install igbinary redis` with `printf "\n" | pecl install igbinary redis` in `docker/phpfpm/Dockerfile`.

Piping `yes` answers `y` to every configure prompt of the `redis` PECL extension, including *"enable msgpack serializer support"*. Since the `msgpack` extension is not installed in the image, the build fails looking for `php_msgpack.h`. Using `printf "\n"` accepts defaults instead, matching the pattern already used in [`docker/kube/Dockerfile`](https://github.com/oat-sa/devkit-lti1p3/blob/master/docker/kube/Dockerfile#L43).

Fixes #184

## Test plan

- [x] `docker compose build devkit_lti1p3_phpfpm` completes successfully.
- [x] `docker compose up -d` brings up all containers and `devkit_lti1p3_phpfpm` reports `ready to handle connections`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker PHP-FPM container build process to handle dependency installation prompts more reliably during image construction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oat-sa/devkit-lti1p3/pull/185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->