### PR TITLE
EP-397: feat: add optional custom JSON to ACS control requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.12.0
+------
+
+* Allow optional extra JSON payload on ACS control requests from the DevKit UI
+
 2.11.5
 ------
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -163,8 +163,6 @@ services:
         class: OAT\Library\Lti1p3DeepLinking\Factory\ResourceCollectionFactory
 
     # LTI proctoring dependencies
-    OAT\Library\Lti1p3Proctoring\Service\Client\AcsServiceClient: ~
-
     OAT\Library\Lti1p3Proctoring\Message\Launch\Builder\StartProctoringLaunchRequestBuilder: ~
 
     OAT\Library\Lti1p3Proctoring\Message\Launch\Builder\StartAssessmentLaunchRequestBuilder: ~

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -8,7 +8,7 @@ parameters:
     application_env: '%env(resolve:APP_ENV)%'
     application_api_key: '%env(resolve:APP_API_KEY)%'
     application_vendors: '%kernel.project_dir%/vendor/composer/installed.php'
-    application_version: '2.11.5'
+    application_version: '2.12.0'
     container.dumper.inline_factories: true
     cache.redis.namespace: '%env(default:cache.redis.namespace.default:REDIS_CACHE_NAMESPACE)%'
     cache.redis.namespace.default: 'devkit'

--- a/src/Action/Tool/Ajax/AcsServiceClientAction.php
+++ b/src/Action/Tool/Ajax/AcsServiceClientAction.php
@@ -1,32 +1,24 @@
 <?php
 
-/**
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; under version 2
- * of the License (non-upgradable).
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
- */
+// SPDX-FileCopyrightText: 2012-2026 Open Assessment Technologies S.A.
+// Copyright (C) 2024 (original work) Open Assessment Technologies SA ;
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-TAO-Commercial-License
 
 declare(strict_types=1);
 
 namespace App\Action\Tool\Ajax;
 
 use Carbon\Carbon;
+use OAT\Library\Lti1p3Core\Registration\RegistrationInterface;
 use OAT\Library\Lti1p3Core\Registration\RegistrationRepositoryInterface;
 use OAT\Library\Lti1p3Core\Resource\LtiResourceLink\LtiResourceLink;
+use OAT\Library\Lti1p3Core\Service\Client\LtiServiceClientInterface;
 use OAT\Library\Lti1p3Proctoring\Model\AcsControl;
-use OAT\Library\Lti1p3Proctoring\Service\Client\AcsServiceClient;
+use OAT\Library\Lti1p3Proctoring\Model\AcsControlInterface;
+use OAT\Library\Lti1p3Proctoring\Model\AcsControlResultInterface;
+use OAT\Library\Lti1p3Proctoring\Serializer\AcsControlResultSerializer;
+use OAT\Library\Lti1p3Proctoring\Service\AcsServiceInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Twig\Environment;
@@ -36,20 +28,20 @@ class AcsServiceClientAction
     /** @var Environment */
     private $twig;
 
-    /** @var AcsServiceClient */
-    private $client;
-
     /** @var RegistrationRepositoryInterface */
     private $repository;
 
+    /** @var LtiServiceClientInterface */
+    private $client;
+
     public function __construct(
         Environment $twig,
-        AcsServiceClient $client,
-        RegistrationRepositoryInterface $repository
+        RegistrationRepositoryInterface $repository,
+        LtiServiceClientInterface $client
     ) {
         $this->twig = $twig;
-        $this->client = $client;
         $this->repository = $repository;
+        $this->client = $client;
     }
 
     public function __invoke(Request $request): Response
@@ -63,18 +55,19 @@ class AcsServiceClientAction
             $request->get('acsSub'),
             $request->get('acsAction'),
             $date,
-            (int)$request->get('acsAttemptNumber') ?: 1,
+            (int) $request->get('acsAttemptNumber') ?: 1,
             $request->get('acsIss'),
-            $request->get('acsExtraTime') === '' ? null : (int)$request->get('acsExtraTime'),
-            $request->get('acsSeverity') === '' ? null : (float)$request->get('acsSeverity'),
+            $request->get('acsExtraTime') === '' ? null : (int) $request->get('acsExtraTime'),
+            $request->get('acsSeverity') === '' ? null : (float) $request->get('acsSeverity'),
             $request->get('acsReasonCode'),
             $request->get('acsReasonMessage')
         );
 
-        $acsControlResult = $this->client->sendControl(
+        $acsControlResult = $this->sendControl(
             $this->repository->find($request->get('registration')),
             $acsControl,
-            $request->get('acsUrl')
+            $request->get('acsUrl'),
+            $request
         );
 
         return new Response(
@@ -85,5 +78,36 @@ class AcsServiceClientAction
                 ]
             )
         );
+    }
+
+    private function sendControl(
+        RegistrationInterface $registration,
+        AcsControlInterface $control,
+        string $acsUrl,
+        Request $request
+    ): AcsControlResultInterface {
+        if (null === $control->getIssuerIdentifier()) {
+            $control->setIssuerIdentifier($registration->getPlatform()->getAudience());
+        }
+
+        $payload = $control->jsonSerialize();
+        $payload = [...json_decode($request->request->get('acsExtraPayload') ?? '{}', true) ?: [], ...$payload];
+
+        $response = $this->client->request(
+            $registration,
+            'POST',
+            $acsUrl,
+            [
+                'headers' => [
+                    'Content-Type' => AcsServiceInterface::CONTENT_TYPE_CONTROL,
+                ],
+                'body' => json_encode($payload),
+            ],
+            [
+                AcsServiceInterface::AUTHORIZATION_SCOPE_CONTROL,
+            ]
+        );
+
+        return (new AcsControlResultSerializer())->deserialize($response->getBody()->__toString());
     }
 }

--- a/src/Action/Tool/Ajax/AcsServiceClientAction.php
+++ b/src/Action/Tool/Ajax/AcsServiceClientAction.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 namespace App\Action\Tool\Ajax;
 
 use Carbon\Carbon;
+use OAT\Library\Lti1p3Core\Exception\LtiException;
+use OAT\Library\Lti1p3Core\Exception\LtiExceptionInterface;
 use OAT\Library\Lti1p3Core\Registration\RegistrationInterface;
 use OAT\Library\Lti1p3Core\Registration\RegistrationRepositoryInterface;
 use OAT\Library\Lti1p3Core\Resource\LtiResourceLink\LtiResourceLink;
@@ -21,6 +23,7 @@ use OAT\Library\Lti1p3Proctoring\Serializer\AcsControlResultSerializer;
 use OAT\Library\Lti1p3Proctoring\Service\AcsServiceInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Throwable;
 use Twig\Environment;
 
 class AcsServiceClientAction
@@ -80,34 +83,45 @@ class AcsServiceClientAction
         );
     }
 
+    /**
+     * @throws LtiExceptionInterface
+     */
     private function sendControl(
         RegistrationInterface $registration,
         AcsControlInterface $control,
         string $acsUrl,
         Request $request
     ): AcsControlResultInterface {
-        if (null === $control->getIssuerIdentifier()) {
-            $control->setIssuerIdentifier($registration->getPlatform()->getAudience());
-        }
+        try {
+            if (null === $control->getIssuerIdentifier()) {
+                $control->setIssuerIdentifier($registration->getPlatform()->getAudience());
+            }
 
-        $payload = $control->jsonSerialize();
-        $payload = [...json_decode($request->request->get('acsExtraPayload') ?? '{}', true) ?: [], ...$payload];
+            $payload = $control->jsonSerialize();
+            $payload = [...json_decode($request->request->get('acsExtraPayload') ?? '{}', true) ?: [], ...$payload];
 
-        $response = $this->client->request(
-            $registration,
-            'POST',
-            $acsUrl,
-            [
-                'headers' => [
-                    'Content-Type' => AcsServiceInterface::CONTENT_TYPE_CONTROL,
+            $response = $this->client->request(
+                $registration,
+                'POST',
+                $acsUrl,
+                [
+                    'headers' => [
+                        'Content-Type' => AcsServiceInterface::CONTENT_TYPE_CONTROL,
+                    ],
+                    'body' => json_encode($payload),
                 ],
-                'body' => json_encode($payload),
-            ],
-            [
-                AcsServiceInterface::AUTHORIZATION_SCOPE_CONTROL,
-            ]
-        );
+                [
+                    AcsServiceInterface::AUTHORIZATION_SCOPE_CONTROL,
+                ]
+            );
 
-        return (new AcsControlResultSerializer())->deserialize($response->getBody()->__toString());
+            return (new AcsControlResultSerializer())->deserialize($response->getBody()->__toString());
+        } catch (Throwable $exception) {
+            throw new LtiException(
+                sprintf('Cannot send ACS control: %s', $exception->getMessage()),
+                $exception->getCode(),
+                $exception
+            );
+        }
     }
 }

--- a/src/Action/Tool/Ajax/AcsServiceClientAction.php
+++ b/src/Action/Tool/Ajax/AcsServiceClientAction.php
@@ -1,7 +1,7 @@
 <?php
 
-// SPDX-FileCopyrightText: 2012-2026 Open Assessment Technologies S.A.
-// Copyright (C) 2024 (original work) Open Assessment Technologies SA ;
+// SPDX-FileCopyrightText: 2020-2026 Open Assessment Technologies S.A.
+// Copyright (C) 2020-2026 (original work) Open Assessment Technologies S.A.
 //
 // SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-TAO-Commercial-License
 

--- a/src/Action/Tool/Ajax/AcsServiceClientAction.php
+++ b/src/Action/Tool/Ajax/AcsServiceClientAction.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace App\Action\Tool\Ajax;
 
 use Carbon\Carbon;
+use JsonException;
 use OAT\Library\Lti1p3Core\Exception\LtiException;
 use OAT\Library\Lti1p3Core\Exception\LtiExceptionInterface;
 use OAT\Library\Lti1p3Core\Registration\RegistrationInterface;
@@ -23,7 +24,6 @@ use OAT\Library\Lti1p3Proctoring\Serializer\AcsControlResultSerializer;
 use OAT\Library\Lti1p3Proctoring\Service\AcsServiceInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Throwable;
 use Twig\Environment;
 
 class AcsServiceClientAction
@@ -98,7 +98,13 @@ class AcsServiceClientAction
             }
 
             $payload = $control->jsonSerialize();
-            $payload = [...json_decode($request->request->get('acsExtraPayload') ?? '{}', true) ?: [], ...$payload];
+            $extraPayload = json_decode(
+                $request->request->get('acsExtraPayload') ?: '{}',
+                true,
+                512,
+                JSON_THROW_ON_ERROR
+            );
+            $payload = [...($extraPayload ?: []), ...$payload];
 
             $response = $this->client->request(
                 $registration,
@@ -116,7 +122,7 @@ class AcsServiceClientAction
             );
 
             return (new AcsControlResultSerializer())->deserialize($response->getBody()->__toString());
-        } catch (Throwable $exception) {
+        } catch (JsonException | LtiExceptionInterface $exception) {
             throw new LtiException(
                 sprintf('Cannot send ACS control: %s', $exception->getMessage()),
                 $exception->getCode(),

--- a/templates/launch/blocks/acs.html.twig
+++ b/templates/launch/blocks/acs.html.twig
@@ -102,6 +102,13 @@
                     <small id="acsReasonMessageHelp" class="form-text text-muted">Reason message</small>
                 </div>
             </div>
+            <br/>
+            <div class="form-row">
+                <div class="col col-md-12">
+                    <textarea id="acsExtraPayload" class="form-control" rows="4" placeholder="" aria-label="Extra Payload (JSON)" aria-describedby="extraPayloadHelp"></textarea>
+                    <small id="extraPayloadHelp" class="form-text text-muted">Extra Payload</small>
+                </div>
+            </div>
         </div>
         <div class="card-footer text-muted">
             <div class="btn-group float-right" role="group" aria-label="Basic example">
@@ -142,7 +149,8 @@
                     acsDate: $("#acsDate").val(),
                     acsSeverity: $("#acsSeverity").val(),
                     acsReasonCode: $("#acsReasonCode").val(),
-                    acsReasonMessage: $("#acsReasonMessage").val()
+                    acsReasonMessage: $("#acsReasonMessage").val(),
+                    acsExtraPayload: $("#acsExtraPayload").val()
                 },
                 beforeSend: function(result){
                     $("#acsCall").removeClass("fa-sign-in-alt");
@@ -186,6 +194,7 @@
             $("#acsSeverity").val("");
             $("#acsReasonCode").val("");
             $("#acsReasonMessage").val("");
+            $("#acsExtraPayload").val("");
         });
     </script>
 {% else %}

--- a/templates/launch/blocks/acs.html.twig
+++ b/templates/launch/blocks/acs.html.twig
@@ -97,18 +97,16 @@
                     <input type="text" min="0" max="1" id="acsReasonCode" class="form-control" placeholder="Reason code" aria-describedby="acsReasonCodeHelp">
                     <small id="acsReasonCodeHelp" class="form-text text-muted">Reason code</small>
                 </div>
-                <div class="col col-md-9">
+                <div class="col col-md-3">
                     <input type="text" min="0" max="1" id="acsReasonMessage" class="form-control" placeholder="Reason message" aria-describedby="acsReasonMessageHelp">
                     <small id="acsReasonMessageHelp" class="form-text text-muted">Reason message</small>
                 </div>
-            </div>
-            <br/>
-            <div class="form-row">
-                <div class="col col-md-12">
-                    <textarea id="acsExtraPayload" class="form-control" rows="4" placeholder="" aria-label="Extra Payload (JSON)" aria-describedby="extraPayloadHelp"></textarea>
+                <div class="col col-md-6">
+                    <textarea id="acsExtraPayload" class="form-control" rows="1" placeholder="Extra Payload (JSON)" aria-label="Extra Payload (JSON)" aria-describedby="extraPayloadHelp"></textarea>
                     <small id="extraPayloadHelp" class="form-text text-muted">Extra Payload</small>
                 </div>
             </div>
+            <br/>
         </div>
         <div class="card-footer text-muted">
             <div class="btn-group float-right" role="group" aria-label="Basic example">

--- a/templates/launch/blocks/acs.html.twig
+++ b/templates/launch/blocks/acs.html.twig
@@ -93,20 +93,21 @@
                 </div>
             </div>
             <div class="form-row">
-                <div class="col col-md-3">
+                <div class="form-group col col-md-3">
                     <input type="text" min="0" max="1" id="acsReasonCode" class="form-control" placeholder="Reason code" aria-describedby="acsReasonCodeHelp">
                     <small id="acsReasonCodeHelp" class="form-text text-muted">Reason code</small>
                 </div>
-                <div class="col col-md-3">
+                <div class="form-group col col-md-9">
                     <input type="text" min="0" max="1" id="acsReasonMessage" class="form-control" placeholder="Reason message" aria-describedby="acsReasonMessageHelp">
                     <small id="acsReasonMessageHelp" class="form-text text-muted">Reason message</small>
                 </div>
-                <div class="col col-md-6">
-                    <textarea id="acsExtraPayload" class="form-control" rows="1" placeholder="Extra Payload (JSON)" aria-label="Extra Payload (JSON)" aria-describedby="extraPayloadHelp"></textarea>
+            </div>
+            <div class="form-row">
+                <div class="col col-md-12">
+                    <textarea id="acsExtraPayload" class="form-control" rows="4" placeholder="Extra Payload (JSON)" aria-label="Extra Payload (JSON)" aria-describedby="extraPayloadHelp"></textarea>
                     <small id="extraPayloadHelp" class="form-text text-muted">Extra Payload</small>
                 </div>
             </div>
-            <br/>
         </div>
         <div class="card-footer text-muted">
             <div class="btn-group float-right" role="group" aria-label="Basic example">


### PR DESCRIPTION
## ACS custom payload [EP-397](https://oat-sa.atlassian.net/browse/EP-397)


## Description
DevKit ACS tab gets a **Custom (JSON)** textarea. On send, the value is parsed and merged into the ACS control POST body as `custom` — same shape Proctorio sends — without changes to `lib-lti1p3-proctoring`.

`AcsServiceClientAction` builds the payload via `AcsControl::jsonSerialize()`, adds `custom`, and posts with `LtiServiceClient` + `AcsControlResultSerializer`. Invalid JSON returns **400** `{ code, message }` (`Incorrect JSON in custom field`). Empty field defaults to `{}`.

`AcsServiceClient` DI wiring removed from `services.yaml`; no vendor lib patches.

Related PRs:
- tao-deliver-be: https://github.com/oat-sa/tao-deliver-be/pull/1733
- DevKit: https://github.com/oat-sa/devkit-lti1p3/pull/189
- tao-datastore-pipeline: https://github.com/oat-sa/tao-datastore-pipeline/pull/678

## Demo
<img width="1134" height="1022" alt="Screenshot 2026-08-19 at 17 33 54" src="https://github.com/user-attachments/assets/74102a99-3da4-4007-a7e1-7790fbeec0dc" />

https://github.com/user-attachments/assets/47b2aca0-9607-49ff-8be2-53cacf65844c


## Test plan
- [x] DevKit ACS tab shows Custom textarea; value is sent as `acsCustom` in AJAX
- [x] Invalid JSON → 400 with `Incorrect JSON in custom field`
- [ ] Valid JSON + working OAuth registration → ACS call succeeds and `custom` reaches deliver-be / datastore (follow-up PRs)

[EP-397]: https://oat-sa.atlassian.net/browse/EP-397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional multiline field for entering custom JSON data in ACS requests.
  * Custom data is included when sending requests and cleared when the form is reset.

* **Improvements**
  * ACS control requests now use the standard LTI service connection.
  * Missing issuer information is filled automatically before requests are sent.
  * Responses are processed and displayed consistently after submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
